### PR TITLE
directly specifiy Miniconda3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         env: PYSAL_PYPI=false
 
 before_install:
-  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH


### PR DESCRIPTION
Using [`/miniconda/Miniconda-latest-Linux-x86_64.sh`](https://github.com/pysal/segregation/blob/0613b5ceeee95cd0334bf59ff5af37d48f86095e/.travis.yml#L22) in [.travis.yml](https://github.com/pysal/segregation/blob/master/.travis.yml) pulls an archaic version of `Miniconda`. 
```
  - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
```

Instead, we should specifically be pulling the latest version of `Miniconda3` from Travis testing.
