### PR TITLE
OK: Create additional argument for the center in Centralization indexes

### DIFF
--- a/segregation/non_spatial_indexes.py
+++ b/segregation/non_spatial_indexes.py
@@ -41,7 +41,7 @@ def _dissim(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -165,7 +165,8 @@ def _gini_seg(data, group_pop_var, total_pop_var):
                     
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
-    Attributes
+                    
+    Returns
     ----------
     statistic : float
                 Gini Segregation Index
@@ -283,7 +284,7 @@ def _entropy(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -410,7 +411,7 @@ def _isolation(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -535,7 +536,7 @@ def _exposure(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -666,7 +667,7 @@ def _atkinson(data, group_pop_var, total_pop_var, b = 0.5):
     b             : float
                     The shape parameter, between 0 and 1, that determines how to weight the increments to segregation contributed by different portions of the Lorenz curve.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -799,7 +800,7 @@ def _correlationr(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -928,7 +929,7 @@ def _conprof(data, group_pop_var, total_pop_var, m = 1000):
                     a numeric value indicating the number of thresholds to be used. Default value is 1000. 
                     A large value of m creates a smoother-looking graph and a more precise concentration profile value but slows down the calculation speed.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1086,7 +1087,7 @@ def _modified_dissim(data, group_pop_var, total_pop_var, iterations = 500):
     iterations    : int
                     The number of iterations the evaluate average classic dissimilarity under eveness. Default value is 500.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1228,7 +1229,7 @@ def _modified_gini_seg(data, group_pop_var, total_pop_var, iterations = 500):
     iterations    : int
                     The number of iterations the evaluate average classic gini segregation under eveness. Default value is 500.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1372,7 +1373,7 @@ def _bias_corrected_dissim(data, group_pop_var, total_pop_var, B = 500):
     B             : int
                     The number of iterations to calculate Dissimilarity simulating randomness with multinomial distributions. Default value is 500.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1517,7 +1518,7 @@ def _density_corrected_dissim(data, group_pop_var, total_pop_var, xtol = 1e-5):
     xtol          : float
                     The degree of tolerance in the optimization process of returning optimal theta_j
 
-    Attributes
+    Returns
     ----------
 
     statistic : float

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -1828,7 +1828,7 @@ class Relative_Concentration:
         
         
         
-def _absolute_centralization(data, group_pop_var, total_pop_var):
+def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"):
     """
     Calculation of Absolute Centralization index
 
@@ -1843,6 +1843,21 @@ def _absolute_centralization(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
+    center        : string, tuple or integer.
+                    This defines what is considered to be the center of the spatial context under study.
+
+                    If string, this can be set to:
+                        
+                        "mean": the center longitude/latitude is the mean of longitudes/latitudes of all units. 
+                        "median": the center longitude/latitude is the median of longitudes/latitudes of all units. 
+                        "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
+                        "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
+                    
+                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    
+                    If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
+                    For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
+
     Attributes
     ----------
 
@@ -1855,6 +1870,8 @@ def _absolute_centralization(data, group_pop_var, total_pop_var):
     Notes
     -----
     Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    A discussion of defining the center in this function can be found in https://github.com/pysal/segregation/issues/18.
 
     """
     
@@ -1886,8 +1903,33 @@ def _absolute_centralization(data, group_pop_var, total_pop_var):
     c_lons = np.array(data.centroid.x)
     c_lats = np.array(data.centroid.y)
     
-    center_lon = c_lons.mean()
-    center_lat = c_lats.mean()
+    if isinstance(center, str):
+        
+        if (center == "mean"):
+            center_lon = c_lons.mean()
+            center_lat = c_lats.mean()
+    
+        if (center == "median"):
+            center_lon = np.median(c_lons)
+            center_lat = np.median(c_lats)
+            
+        if (center == "population_weighted_mean"):
+            center_lon = np.average(c_lons, weights = t)
+            center_lat = np.average(c_lats, weights = t)
+    
+        if (center == "largest_population"):
+            center_lon = c_lons[np.where(t == t.max())].mean()
+            center_lat = c_lats[np.where(t == t.max())].mean()
+
+    if isinstance(center, tuple):
+        
+        center_lon = center[0]
+        center_lat = center[1]
+    
+    if isinstance(center, int):
+        
+        center_lon = data.iloc[[center]].centroid.x.values[0]
+        center_lat = data.iloc[[center]].centroid.y.values[0]
     
     X = x.sum()
     A = area.sum()
@@ -1925,6 +1967,21 @@ class Absolute_Centralization:
                     
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
+                    
+    center        : string, tuple or integer.
+                    This defines what is considered to be the center of the spatial context under study.
+
+                    If string, this can be set to:
+                        
+                        "mean": the center longitude/latitude is the mean of longitudes/latitudes of all units. 
+                        "median": the center longitude/latitude is the median of longitudes/latitudes of all units. 
+                        "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
+                        "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
+                    
+                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    
+                    If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
+                    For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
 
     Attributes
     ----------
@@ -1973,12 +2030,14 @@ class Absolute_Centralization:
     Notes
     -----
     Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    A discussion of defining the center in this function can be found in https://github.com/pysal/segregation/issues/18.
 
     """
 
-    def __init__(self, data, group_pop_var, total_pop_var):
+    def __init__(self, data, group_pop_var, total_pop_var, center = "mean"):
         
-        aux = _absolute_centralization(data, group_pop_var, total_pop_var)
+        aux = _absolute_centralization(data, group_pop_var, total_pop_var, center)
 
         self.statistic = aux[0]
         self.core_data = aux[1]
@@ -1986,7 +2045,7 @@ class Absolute_Centralization:
         
         
         
-def _relative_centralization(data, group_pop_var, total_pop_var):
+def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"):
     """
     Calculation of Relative Centralization index
 
@@ -2001,6 +2060,21 @@ def _relative_centralization(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
+    center        : string, tuple or integer.
+                    This defines what is considered to be the center of the spatial context under study.
+
+                    If string, this can be set to:
+                        
+                        "mean": the center longitude/latitude is the mean of longitudes/latitudes of all units. 
+                        "median": the center longitude/latitude is the median of longitudes/latitudes of all units. 
+                        "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
+                        "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
+                    
+                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    
+                    If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
+                    For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
+
     Attributes
     ----------
 
@@ -2013,6 +2087,8 @@ def _relative_centralization(data, group_pop_var, total_pop_var):
     Notes
     -----
     Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    A discussion of defining the center in this function can be found in https://github.com/pysal/segregation/issues/18.
 
     """
     if (str(type(data)) != '<class \'geopandas.geodataframe.GeoDataFrame\'>'):
@@ -2043,8 +2119,33 @@ def _relative_centralization(data, group_pop_var, total_pop_var):
     c_lons = np.array(data.centroid.x)
     c_lats = np.array(data.centroid.y)
     
-    center_lon = c_lons.mean()
-    center_lat = c_lats.mean()
+    if isinstance(center, str):
+        
+        if (center == "mean"):
+            center_lon = c_lons.mean()
+            center_lat = c_lats.mean()
+    
+        if (center == "median"):
+            center_lon = np.median(c_lons)
+            center_lat = np.median(c_lats)
+            
+        if (center == "population_weighted_mean"):
+            center_lon = np.average(c_lons, weights = t)
+            center_lat = np.average(c_lats, weights = t)
+    
+        if (center == "largest_population"):
+            center_lon = c_lons[np.where(t == t.max())].mean()
+            center_lat = c_lats[np.where(t == t.max())].mean()
+
+    if isinstance(center, tuple):
+        
+        center_lon = center[0]
+        center_lat = center[1]
+    
+    if isinstance(center, int):
+        
+        center_lon = data.iloc[[center]].centroid.x.values[0]
+        center_lat = data.iloc[[center]].centroid.y.values[0]
     
     X = x.sum()
     Y = y.sum()
@@ -2078,6 +2179,21 @@ class Relative_Centralization:
                     
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
+
+    center        : string, tuple or integer.
+                    This defines what is considered to be the center of the spatial context under study.
+
+                    If string, this can be set to:
+                        
+                        "mean": the center longitude/latitude is the mean of longitudes/latitudes of all units. 
+                        "median": the center longitude/latitude is the median of longitudes/latitudes of all units. 
+                        "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
+                        "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
+                    
+                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    
+                    If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
+                    For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
 
     Attributes
     ----------
@@ -2126,12 +2242,14 @@ class Relative_Centralization:
     Notes
     -----
     Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    A discussion of defining the center in this function can be found in https://github.com/pysal/segregation/issues/18.
 
     """
 
-    def __init__(self, data, group_pop_var, total_pop_var):
+    def __init__(self, data, group_pop_var, total_pop_var, center = "mean"):
         
-        aux = _relative_centralization(data, group_pop_var, total_pop_var)
+        aux = _relative_centralization(data, group_pop_var, total_pop_var, center)
 
         self.statistic = aux[0]
         self.core_data = aux[1]

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -1843,7 +1843,7 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    center        : string, tuple or integer.
+    center        : string, two-dimension values (tuple, list, array) or integer.
                     This defines what is considered to be the center of the spatial context under study.
 
                     If string, this can be set to:
@@ -1853,7 +1853,7 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
                         "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
                         "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
                     
-                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    If tuple, list or array, this argument should be the coordinates of the desired center assuming longitude as first value and latitude second value. Therefore, in the form (longitude, latitude), if tuple, or [longitude, latitude] if list or numpy array.
                     
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
@@ -1904,6 +1904,8 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
     c_lats = np.array(data.centroid.y)
     
     if isinstance(center, str):
+        if not center in ['mean', 'median', 'population_weighted_mean', 'largest_population']:
+            raise ValueError('The center string must one of \'mean\', \'median\', \'population_weighted_mean\', \'largest_population\'')
         
         if (center == "mean"):
             center_lon = c_lons.mean()
@@ -1921,13 +1923,17 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
             center_lon = c_lons[np.where(t == t.max())].mean()
             center_lat = c_lats[np.where(t == t.max())].mean()
 
-    if isinstance(center, tuple):
+    if isinstance(center, tuple) or isinstance(center, list) or isinstance(center, np.ndarray):
+        if np.array(center).shape != (2,):
+            raise ValueError('The center tuple/list/array must have length 2.')
         
         center_lon = center[0]
         center_lat = center[1]
     
     if isinstance(center, int):
-        
+        if (center > len(data) - 1) or (center < 0):
+            raise ValueError('The center index must by in the range of data.')
+
         center_lon = data.iloc[[center]].centroid.x.values[0]
         center_lat = data.iloc[[center]].centroid.y.values[0]
     
@@ -1968,7 +1974,7 @@ class Absolute_Centralization:
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
                     
-    center        : string, tuple or integer.
+    center        : string, two-dimension values (tuple, list, array) or integer.
                     This defines what is considered to be the center of the spatial context under study.
 
                     If string, this can be set to:
@@ -1978,7 +1984,7 @@ class Absolute_Centralization:
                         "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
                         "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
                     
-                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    If tuple, list or array, this argument should be the coordinates of the desired center assuming longitude as first value and latitude second value. Therefore, in the form (longitude, latitude), if tuple, or [longitude, latitude] if list or numpy array.
                     
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
@@ -2060,7 +2066,7 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    center        : string, tuple or integer.
+    center        : string, two-dimension values (tuple, list, array) or integer.
                     This defines what is considered to be the center of the spatial context under study.
 
                     If string, this can be set to:
@@ -2070,7 +2076,7 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
                         "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
                         "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
                     
-                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    If tuple, list or array, this argument should be the coordinates of the desired center assuming longitude as first value and latitude second value. Therefore, in the form (longitude, latitude), if tuple, or [longitude, latitude] if list or numpy array.
                     
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
@@ -2120,6 +2126,8 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
     c_lats = np.array(data.centroid.y)
     
     if isinstance(center, str):
+        if not center in ['mean', 'median', 'population_weighted_mean', 'largest_population']:
+            raise ValueError('The center string must one of \'mean\', \'median\', \'population_weighted_mean\', \'largest_population\'')
         
         if (center == "mean"):
             center_lon = c_lons.mean()
@@ -2137,13 +2145,17 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
             center_lon = c_lons[np.where(t == t.max())].mean()
             center_lat = c_lats[np.where(t == t.max())].mean()
 
-    if isinstance(center, tuple):
+    if isinstance(center, tuple) or isinstance(center, list) or isinstance(center, np.ndarray):
+        if np.array(center).shape != (2,):
+            raise ValueError('The center tuple/list/array must have length 2.')
         
         center_lon = center[0]
         center_lat = center[1]
     
     if isinstance(center, int):
-        
+        if (center > len(data) - 1) or (center < 0):
+            raise ValueError('The center index must by in the range of data.')
+
         center_lon = data.iloc[[center]].centroid.x.values[0]
         center_lat = data.iloc[[center]].centroid.y.values[0]
     
@@ -2180,7 +2192,7 @@ class Relative_Centralization:
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    center        : string, tuple or integer.
+    center        : string, two-dimension values (tuple, list, array) or integer.
                     This defines what is considered to be the center of the spatial context under study.
 
                     If string, this can be set to:
@@ -2190,7 +2202,7 @@ class Relative_Centralization:
                         "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
                         "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
                     
-                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
+                    If tuple, list or array, this argument should be the coordinates of the desired center assuming longitude as first value and latitude second value. Therefore, in the form (longitude, latitude), if tuple, or [longitude, latitude] if list or numpy array.
                     
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -57,7 +57,7 @@ def _spatial_prox_profile(data, group_pop_var, total_pop_var, m = 1000):
                     a numeric value indicating the number of thresholds to be used. Default value is 1000. 
                     A large value of m creates a smoother-looking graph and a more precise spatial proximity profile value but slows down the calculation speed.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -242,8 +242,7 @@ def _spatial_dissim(data, group_pop_var, total_pop_var, w = None, standardize = 
                     For the sake of comparison, the seg R package of Hong, Seong-Yun, David O'Sullivan, and Yukio Sadahiro. "Implementing spatial segregation measures in R." PloS one 9.11 (2014): e113767.
                     works by default with row standardization.
         
-
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -430,8 +429,7 @@ def _boundary_spatial_dissim(data, group_pop_var, total_pop_var, standardize = F
                     For the sake of comparison, the seg R package of Hong, Seong-Yun, David O'Sullivan, and Yukio Sadahiro. "Implementing spatial segregation measures in R." PloS one 9.11 (2014): e113767.
                     works by default without row standardization. That is, directly with border length.
         
-
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -586,7 +584,7 @@ def _perimeter_area_ratio_spatial_dissim(data, group_pop_var, total_pop_var, sta
                     A condition for standardisation of the weights matrices. 
                     If True, the values of cij in the formulas gets standardized and the overall sum is 1.
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -744,7 +742,7 @@ def _spatial_isolation(data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -914,7 +912,7 @@ def _spatial_exposure(data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0.
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1083,7 +1081,8 @@ def _spatial_proximity(data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0
     
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
-    Attributes
+                    
+    Returns
     ----------
     statistic : float
                 Spatial Proximity Index
@@ -1167,6 +1166,7 @@ class Spatial_Proximity:
     
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
+                    
     Attributes
     ----------
     statistic : float
@@ -1246,7 +1246,8 @@ def _relative_clustering(data, group_pop_var, total_pop_var, alpha = 0.6, beta =
     
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
-    Attributes
+                    
+    Returns
     ----------
     statistic : float
                 Relative Clustering Index
@@ -1326,6 +1327,7 @@ class Relative_Clustering:
     
     beta          : float
                     A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
+                    
     Attributes
     ----------
     statistic : float
@@ -1401,7 +1403,7 @@ def _delta(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1539,7 +1541,7 @@ def _absolute_concentration(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1689,7 +1691,7 @@ def _relative_concentration(data, group_pop_var, total_pop_var):
     total_pop_var : string
                     The name of variable in data that contains the total population of the unit
 
-    Attributes
+    Returns
     ----------
 
     statistic : float
@@ -1858,7 +1860,7 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
 
-    Attributes
+    Returns
     ----------
 
     statistic     : float
@@ -2086,7 +2088,7 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
                     If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                     For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.
 
-    Attributes
+    Returns
     ----------
 
     statistic     : float
@@ -2309,7 +2311,7 @@ def _spatial_information_theory(data, group_pop_var, total_pop_var, w = None, un
                         This argument is also to avoid passing data without crs and, therefore, raising unusual results.
                         This index rely on the population density and we consider the area using squared kilometers. 
 
-    Attributes
+    Returns
     ----------
 
     statistic : float

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -1861,12 +1861,15 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
     Attributes
     ----------
 
-    statistic : float
-                Absolute Centralization Index
+    statistic     : float
+                    Absolute Centralization Index
                 
-    core_data : a geopandas DataFrame
-                A geopandas DataFrame that contains the columns used to perform the estimate.
-                
+    core_data     : a geopandas DataFrame
+                    A geopandas DataFrame that contains the columns used to perform the estimate.
+    
+    center_values : list
+                    The center, in the form [longitude, latitude], values used for the calculation of the centralization distances.
+    
     Notes
     -----
     Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
@@ -1952,7 +1955,9 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
     
     core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
     
-    return ACE, core_data
+    center_values = [center_lon, center_lat]
+    
+    return ACE, core_data, center_values
 
 
 class Absolute_Centralization:
@@ -1988,11 +1993,14 @@ class Absolute_Centralization:
     Attributes
     ----------
 
-    statistic : float
-                Absolute Centralization Index
+    statistic     : float
+                    Absolute Centralization Index
                 
-    core_data : a geopandas DataFrame
-                A geopandas DataFrame that contains the columns used to perform the estimate.
+    core_data     : a geopandas DataFrame
+                    A geopandas DataFrame that contains the columns used to perform the estimate.
+    
+    center_values : list
+                    The center, in the form [longitude, latitude], values used for the calculation of the centralization distances.
                 
     Examples
     --------
@@ -2041,9 +2049,10 @@ class Absolute_Centralization:
         
         aux = _absolute_centralization(data, group_pop_var, total_pop_var, center)
 
-        self.statistic = aux[0]
-        self.core_data = aux[1]
-        self._function = _absolute_centralization
+        self.statistic     = aux[0]
+        self.core_data     = aux[1]
+        self.center_values = aux[2]
+        self._function     = _absolute_centralization
         
         
         
@@ -2080,11 +2089,14 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
     Attributes
     ----------
 
-    statistic : float
-                Relative Centralization Index
+    statistic     : float
+                    Absolute Centralization Index
                 
-    core_data : a geopandas DataFrame
-                A geopandas DataFrame that contains the columns used to perform the estimate.
+    core_data     : a geopandas DataFrame
+                    A geopandas DataFrame that contains the columns used to perform the estimate.
+    
+    center_values : list
+                    The center, in the form [longitude, latitude], values used for the calculation of the centralization distances.
 
     Notes
     -----
@@ -2169,8 +2181,10 @@ def _relative_centralization(data, group_pop_var, total_pop_var, center = "mean"
           np.nansum(Xi * shift(Yi, 1, cval=np.NaN))
 
     core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
+    
+    center_values = [center_lon, center_lat]
 
-    return RCE, core_data
+    return RCE, core_data, center_values
 
 
 class Relative_Centralization:
@@ -2206,11 +2220,14 @@ class Relative_Centralization:
     Attributes
     ----------
 
-    statistic : float
-                Relative Centralization Index
-                
-    core_data : a geopandas DataFrame
-                A geopandas DataFrame that contains the columns used to perform the estimate.
+    statistic     : float
+                    Absolute Centralization Index
+            
+    core_data     : a geopandas DataFrame
+                    A geopandas DataFrame that contains the columns used to perform the estimate.
+    
+    center_values : list
+                    The center, in the form [longitude, latitude], values used for the calculation of the centralization distances.
         
     Examples
     --------
@@ -2259,8 +2276,9 @@ class Relative_Centralization:
         
         aux = _relative_centralization(data, group_pop_var, total_pop_var, center)
 
-        self.statistic = aux[0]
-        self.core_data = aux[1]
+        self.statistic     = aux[0]
+        self.core_data     = aux[1]
+        self.center_values = aux[2]
         self._function = _relative_centralization
         
         

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -1953,10 +1953,6 @@ def _absolute_centralization(data, group_pop_var, total_pop_var, center = "mean"
     core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
     
     return ACE, core_data
-    
-    core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
-    
-    return ACE, core_data
 
 
 class Absolute_Centralization:


### PR DESCRIPTION
This is a PR that address https://github.com/pysal/segregation/issues/18.

I've been working in this issue and pushed this commit here with several approaches for all centralization indexes with this new argument:
```
    center        : string, tuple or integer.
                    This defines what is considered to be the center of the spatial context under study.

                    If string, this can be set to:
                        
                        "mean": the center longitude/latitude is the mean of longitudes/latitudes of all units. 
                        "median": the center longitude/latitude is the median of longitudes/latitudes of all units. 
                        "population_weighted_mean": the center longitude/latitude is the mean of longitudes/latitudes of all units weighted by the total population.
                        "largest_population": the center longitude/latitude is the centroid of the unit with largest total population. If there is a tie in the maximum population, the mean of all coordinates will be taken.
                    
                    If tuple, this argument should be the coordinates of the desired center in the form (longitude, latitude).
                    
                    If integer, the center will be the centroid of the polygon from data corresponding to the integer interpreted as index. 
                    For example, if `center = 0` the centroid of the first row of data is used as center, if `center = 1` the second row will be used, and so on.

```

I think that the point here is that the function can be generic enough so the user can work with different approaches for the center. Virtually, passing a tuple (second option for the function), the user can fit with any given center (this could be the centroid of the Central Business District if the user knows where it is).

Regarding the LEHD idea, it is pretty cool! However, this is only available only for the US. Therefore, I think we can open an issue only for this task.

I think the multiple cores in the same spatial context should be addressed in a different index of segregation that would deal with that somehow... I never saw one and would be interested if someone finds it!


I really wanted to add @weikang9009  as a reviewer of this PR, but she doesn't appear in the options even when I search for her GitHub username (if someone could add her as a possible reviewer (or allow I add her), I appreciate that):
![image](https://user-images.githubusercontent.com/22593188/57713159-c2c47300-7626-11e9-93b2-ba6b31ef02c1.png)


ps.: This PR was originally created in another that was closed, because I wanted to "clean" my master branch.