### PR TITLE
add bootstrap (for unit levels) for single value segregation

### DIFF
--- a/segregation/inference_wrappers.py
+++ b/segregation/inference_wrappers.py
@@ -27,6 +27,7 @@ def _infer_segregation(seg_class, iterations_under_null = 500, null_approach = "
     null_approach : argument that specifies which type of null hypothesis the inference will iterate.
     
         "systematic"             : assumes that every group has the same probability with restricted conditional probabilities p_0_j = p_1_j = p_j = n_j/n (multinomial distribution).
+        "bootstrap"              : generates bootstrap replications of the units with replacement of the same size of the original data.
         "evenness"               : assumes that each spatial unit has the same global probability of drawing elements from the minority group of the fixed total unit population (binomial distribution).
         
         "permutation"            : randomly allocates the units over space keeping the original values.
@@ -98,6 +99,21 @@ def _infer_segregation(seg_class, iterations_under_null = 500, null_approach = "
                 df_aux['geometry'] = data['geometry']
                 
             Estimates_Stars[i] = seg_class._function(df_aux, 'simul_group', 'simul_tot', **kwargs)[0]
+            
+            print('Processed {} iterations out of {}.'.format(i + 1, iterations_under_null), end = "\r")
+    
+    #############
+    # BOOTSTRAP #
+    #############
+    if (null_approach == "bootstrap"):
+        
+        Estimates_Stars = np.empty(iterations_under_null)
+        
+        for i in np.array(range(iterations_under_null)):
+            
+            sample_index = np.random.choice(data.index, size = len(data), replace = True)
+            df_aux = data.iloc[sample_index]
+            Estimates_Stars[i] = seg_class._function(df_aux, 'group_pop_var', 'total_pop_var', **kwargs)[0]
             
             print('Processed {} iterations out of {}.'.format(i + 1, iterations_under_null), end = "\r")
     
@@ -229,6 +245,7 @@ class Infer_Segregation:
     null_approach : argument that specifies which type of null hypothesis the inference will iterate.
     
         "systematic"             : assumes that every group has the same probability with restricted conditional probabilities p_0_j = p_1_j = p_j = n_j/n (multinomial distribution).
+        "bootstrap"              : generates bootstrap replications of the units with replacement of the same size of the original data.
         "evenness"               : assumes that each spatial unit has the same global probability of drawing elements from the minority group of the fixed total unit population (binomial distribution).
         
         "permutation"            : randomly allocates the units over space keeping the original values.

--- a/segregation/inference_wrappers.py
+++ b/segregation/inference_wrappers.py
@@ -57,9 +57,9 @@ def _infer_segregation(seg_class, iterations_under_null = 500, null_approach = "
     The one-tailed p_value attribute might not be appropriate for some measures, as the two-tailed. Therefore, it is better to rely on the est_sim attribute.
     
     '''
-    if not null_approach in ['systematic', 'evenness', 'permutation', 'systematic_permutation', 'even_permutation']:
-        raise ValueError('null_approach must one of \'systematic\', \'evenness\', \'permutation\', \'systematic_permutation\', \'even_permutation\'')
-    
+    if not null_approach in ['systematic', 'bootstrap', 'evenness', 'permutation', 'systematic_permutation', 'even_permutation']:
+        raise ValueError('null_approach must one of \'systematic\', \'bootstrap\', \'evenness\', \'permutation\', \'systematic_permutation\', \'even_permutation\'')
+        
     if (type(two_tailed) is not bool):
         raise TypeError('two_tailed is not a boolean object')
     


### PR DESCRIPTION
This adds the bootstrap approach for single value. The size of the samples generated in each permutation is the same as the original sample size. Note that this resamples the units.... this could also be extended to generate samples from the individual. But I think that this current approach is already valuable to add in the module.

One thing that I noticed is that this approach is very sensitive to the sample size (which in our case is always fixed and the number of rows in the dataset... we could flexibilize that also), which might be a desired property. It is very likely that this approach generates distributions around the original sample estimate which, consequently, flagging not significant segregation measures. At least for eveness dimensions (dissimilarty, gini, etc.) I honestly think that our classical `eveness` approach suits better.

I think this is a good opportunity to discuss this in more details for an inference paper.

This is also implemented in OasisR (https://cran.r-project.org/web/packages/OasisR/OasisR.pdf) which I've been studying the internal functions. The results of this bootstrap approach of this PR is the same as OasisR.