### PR TITLE
change denominator of spatial interaction term of Perimeter_Area_Ratio_Spatial_Dissim (and also add some tweak for concentration indexes)

### DIFF
--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -632,7 +632,7 @@ def _perimeter_area_ratio_spatial_dissim(data, group_pop_var, total_pop_var, sta
     max_pa = max(peri / ai)
     
     num = np.multiply(np.multiply(manhattan_distances(data[['pi']]), cij), aux_sum).sum()
-    den = 4 * max_pa
+    den = 2 * max_pa
     
     PARD = D - (num / den)
     PARD

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -1599,11 +1599,11 @@ def _absolute_concentration(data, group_pop_var, total_pop_var):
     n2 = np.where(((np.cumsum(t[des_ind]) / T) < X/T) == False)[0][0]
     
     n = data.shape[0]
-    T1 =  t[asc_ind][0:(n1+1)].sum()
+    T1 =  t[asc_ind][0:n1].sum()
     T2 =  t[asc_ind][n2:n].sum()
     
-    ACO = 1- ((((x[asc_ind] * area[asc_ind] / X).sum()) - ((t[asc_ind] * area[asc_ind] / T1)[0:(n1 + 1)].sum())) / \
-          (((t[asc_ind] * area[asc_ind] / T2)[n2:n].sum()) - ((t[asc_ind] * area[asc_ind]/T1)[0:(n1 + 1)].sum())))
+    ACO = 1- ((((x[asc_ind] * area[asc_ind] / X).sum()) - ((t[asc_ind] * area[asc_ind] / T1)[0:n1].sum())) / \
+          (((t[asc_ind] * area[asc_ind] / T2)[n2:n].sum()) - ((t[asc_ind] * area[asc_ind]/T1)[0:n1].sum())))
 
     core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
 
@@ -1752,11 +1752,11 @@ def _relative_concentration(data, group_pop_var, total_pop_var):
     n2 = np.where(((np.cumsum(t[des_ind]) / T) < X/T) == False)[0][0]
     
     n  = data.shape[0]
-    T1 = t[asc_ind][0:(n1+1)].sum()
+    T1 = t[asc_ind][0:n1].sum()
     T2 = t[asc_ind][n2:n].sum()
     
     RCO = ((((x[asc_ind] * area[asc_ind] / X).sum()) / ((y[asc_ind] * area[asc_ind] / Y).sum())) - 1) / \
-          ((((t[asc_ind] * area[asc_ind])[0:(n1+1)].sum() / T1) / ((t[asc_ind] * area[asc_ind])[n2:n].sum() / T2)) - 1)
+          ((((t[asc_ind] * area[asc_ind])[0:n1].sum() / T1) / ((t[asc_ind] * area[asc_ind])[n2:n].sum() / T2)) - 1)
     
     core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
     

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -595,7 +595,11 @@ def _perimeter_area_ratio_spatial_dissim(data, group_pop_var, total_pop_var, sta
                 
     Notes
     -----
-    Based on Wong, David WS. "Spatial indices of segregation." Urban studies 30.3 (1993): 559-572.
+    Originally based on Wong, David WS. "Spatial indices of segregation." Urban studies 30.3 (1993): 559-572.
+    
+    However, Tivadar, Mihai. "OasisR: An R Package to Bring Some Order to the World of Segregation Measurement." Journal of Statistical Software 89.1 (2019): 1-39.
+    points out that in Wong’s original there is an issue with the formula which is an extra division by 2 in the spatial interaction component.
+    This function follows the formula present in the first Appendix of Tivadar, Mihai. "OasisR: An R Package to Bring Some Order to the World of Segregation Measurement." Journal of Statistical Software 89.1 (2019): 1-39.
 
     """
     
@@ -707,7 +711,11 @@ class Perimeter_Area_Ratio_Spatial_Dissim:
             
     Notes
     -----
-    Based on Wong, David WS. "Spatial indices of segregation." Urban studies 30.3 (1993): 559-572.
+    Originally based on Wong, David WS. "Spatial indices of segregation." Urban studies 30.3 (1993): 559-572.
+    
+    However, Tivadar, Mihai. "OasisR: An R Package to Bring Some Order to the World of Segregation Measurement." Journal of Statistical Software 89.1 (2019): 1-39.
+    points out that in Wong’s original there is an issue with the formula which is an extra division by 2 in the spatial interaction component.
+    This function follows the formula present in the first Appendix of Tivadar, Mihai. "OasisR: An R Package to Bring Some Order to the World of Segregation Measurement." Journal of Statistical Software 89.1 (2019): 1-39.
     
     """
 

--- a/segregation/tests/test_absolute_concentration.py
+++ b/segregation/tests/test_absolute_concentration.py
@@ -11,7 +11,7 @@ class Absolute_Concentration_Tester(unittest.TestCase):
         s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         index = Absolute_Concentration(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.21496583971774408)
+        np.testing.assert_almost_equal(index.statistic, 0.21492220758219194)
 
 if __name__ == '__main__':
     unittest.main()

--- a/segregation/tests/test_perimeter_area_ratio_spatial_dissimilarity.py
+++ b/segregation/tests/test_perimeter_area_ratio_spatial_dissimilarity.py
@@ -11,7 +11,7 @@ class Perimeter_Area_Ratio_Spatial_Dissim_Tester(unittest.TestCase):
         s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         index = Perimeter_Area_Ratio_Spatial_Dissim(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.3165091834802075)
+        np.testing.assert_almost_equal(index.statistic, 0.3111718061947464)
 
 if __name__ == '__main__':
     unittest.main()

--- a/segregation/tests/test_relative_concentration.py
+++ b/segregation/tests/test_relative_concentration.py
@@ -11,7 +11,7 @@ class Relative_Concentration_Tester(unittest.TestCase):
         s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         index = Relative_Concentration(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.13102848628073688)
+        np.testing.assert_almost_equal(index.statistic, 0.13100189111249014)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've been studying deeply OasisR and one thing that I originally spotted that might be wrong was also discussed in Tivadar (2019). 

I'm comparing all of our function with the R implementation and, so far, I'm getting the exact same results. However, for the Perimeter_Area_Ratio_Spatial_Dissim this PR changes the formula to

![image](https://user-images.githubusercontent.com/22593188/58772726-0861c500-856f-11e9-87d5-c9a23bb03415.png)

rather than the original version of Wong (1993):

![image](https://user-images.githubusercontent.com/22593188/58772753-23ccd000-856f-11e9-888c-55144ce32b2f.png)

In terms of changing values, this is not very substantial for the examples I'm running locally.

The Notes in the doctrings mentioned this.
