### PR TITLE
add Absolute Clustering (ACL) segregation measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ For point estimation, all the measures available can be summarized in the follow
 | Spatial Isolation (SxPx)                          | Spatial\_Isolation                      |     Yes      |     alpha, beta     |
 | Spatial Exposure (SxPy)                           | Spatial\_Exposure                       |     Yes      |     alpha, beta     |
 | Spatial Proximity (SP)                            | Spatial\_Proximity                      |     Yes      |     alpha, beta     |
+| Absolute Clustering (ACL)                         | Absolute\_Clustering                    |     Yes      |     alpha, beta     |
 | Relative Clustering (RCL)                         | Relative\_Clustering                    |     Yes      |     alpha, beta     |
 | Delta (DEL)                                       | Delta                                   |     Yes      |         \-          |
 | Absolute Concentration (ACO)                      | Absolute\_Concentration                 |     Yes      |         \-          |

--- a/notebooks/spatial_examples.ipynb
+++ b/notebooks/spatial_examples.ipynb
@@ -108,7 +108,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x283e365e1d0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1a90d4ad8d0>"
       ]
      },
      "execution_count": 4,
@@ -400,7 +400,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\users\\renan\\desktop\\segregation\\segregation\\spatial_indexes.py:108: RuntimeWarning: invalid value encountered in long_scalars\n",
+      "c:\\users\\renan\\desktop\\segregation\\segregation\\spatial_indexes.py:112: RuntimeWarning: invalid value encountered in true_divide\n",
       "  eta_t = (k**2 - k) / den\n"
      ]
     },
@@ -456,7 +456,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x283e367fcc0>"
+       "<matplotlib.collections.PathCollection at 0x1a91310ed30>"
       ]
      },
      "execution_count": 13,
@@ -564,12 +564,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Relative Clustering\n",
+    "### Absolute Clustering\n",
     "\n",
-    "The Relative Clustering Measure (RCL) is given by:\n",
+    "The Absolute Clustering Measure (ACL) is given by:\n",
     "\n",
     "\\begin{equation}\n",
-    "RCL = \\frac{P_{xx}}{P_{yy}} - 1\n",
+    "ACL = \\frac{\\left (\\sum_{i_1=1}^{I}\\left ( \\frac{x_{i_1}}{X} \\right )\\sum_{i_2=1}^{I}\\zeta_{i_1i_2}x_{i_2}  \\right ) - \\left ( \\frac{X}{n^2}\\sum_{i_1=1}^{I}\\sum_{i_2=1}^{I}\\zeta_{i_1i_2} \\right )}{\\left (\\sum_{i_1=1}^{I}\\left ( \\frac{x_{i_1}}{X} \\right )\\sum_{i_2=1}^{I}\\zeta_{i_1i_2}t_{i_2}  \\right ) - \\left ( \\frac{X}{n^2}\\sum_{i_1=1}^{I}\\sum_{i_2=1}^{I}\\zeta_{i_1i_2} \\right )}\n",
     "\\end{equation}"
    ]
   },
@@ -588,10 +588,72 @@
     {
      "data": {
       "text/plain": [
-       "segregation.spatial_indexes.Relative_Clustering"
+       "segregation.spatial_indexes.Absolute_Clustering"
       ]
      },
      "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from segregation.spatial_indexes import Absolute_Clustering\n",
+    "index = Absolute_Clustering(gdf, 'HISP_', 'TOT_POP', alpha = 0.6, beta = 0.5)\n",
+    "type(index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.005189287311955573"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index.statistic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Relative Clustering\n",
+    "\n",
+    "The Relative Clustering Measure (RCL) is given by:\n",
+    "\n",
+    "\\begin{equation}\n",
+    "RCL = \\frac{P_{xx}}{P_{yy}} - 1\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The index is fitted below (note you can choose alpha and beta):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "segregation.spatial_indexes.Relative_Clustering"
+      ]
+     },
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -604,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -613,7 +675,7 @@
        "0.009095632468738568"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -667,7 +729,7 @@
        "segregation.spatial_indexes.Spatial_Isolation"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -680,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -689,7 +751,7 @@
        "0.1562162475606278"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -722,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -731,7 +793,7 @@
        "segregation.spatial_indexes.Spatial_Exposure"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -744,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -753,7 +815,7 @@
        "0.8396583368412371"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -786,7 +848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -795,7 +857,7 @@
        "segregation.spatial_indexes.Delta"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -808,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -817,7 +879,7 @@
        "0.8044969214141899"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -861,7 +923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -870,7 +932,7 @@
        "segregation.spatial_indexes.Absolute_Concentration"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -883,7 +945,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -892,7 +954,7 @@
        "0.21496583971774408"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -926,7 +988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +997,7 @@
        "segregation.spatial_indexes.Relative_Concentration"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -948,7 +1010,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -957,7 +1019,7 @@
        "0.13102848628073688"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -994,7 +1056,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1003,7 +1065,7 @@
        "segregation.spatial_indexes.Absolute_Centralization"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1016,7 +1078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1025,7 +1087,7 @@
        "0.6891422368736286"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1043,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1052,7 +1114,7 @@
        "segregation.spatial_indexes.Relative_Centralization"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1065,7 +1127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1074,7 +1136,7 @@
        "-0.11194177550430595"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1106,7 +1168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1115,7 +1177,7 @@
        "segregation.spatial_indexes.Spatial_Information_Theory"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1128,7 +1190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1137,7 +1199,7 @@
        "0.778177518074913"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/segregation/spatial_indexes.py
+++ b/segregation/spatial_indexes.py
@@ -29,6 +29,7 @@ __all__ = ['Spatial_Prox_Prof',
            'Spatial_Isolation',
            'Spatial_Exposure',
            'Spatial_Proximity',
+           'Absolute_Clustering',
            'Relative_Clustering',
            'Delta',
            'Absolute_Concentration',
@@ -1225,6 +1226,171 @@ class Spatial_Proximity:
         self.statistic = aux[0]
         self.core_data = aux[1]
         self._function = _spatial_proximity
+
+
+def _absolute_clustering(data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0.5):
+    """
+    Calculation of Absolute Clustering index
+    
+    Parameters
+    ----------
+    data          : a geopandas DataFrame with a geometry column.
+    
+    group_pop_var : string
+                    The name of variable in data that contains the population size of the group of interest
+                    
+    total_pop_var : string
+                    The name of variable in data that contains the total population of the unit
+                    
+    alpha         : float
+                    A parameter that estimates the extent of the proximity within the same unit. Default value is 0.6
+    
+    beta          : float
+                    A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
+                    
+    Returns
+    ----------
+    statistic : float
+                Absolute Clustering Index
+                
+    core_data : a geopandas DataFrame
+                A geopandas DataFrame that contains the columns used to perform the estimate.
+    Notes
+    -----
+    Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    The pairwise distance between unit i and itself is (alpha * area_of_unit_i) ^ beta.
+    """
+    
+    if (str(type(data)) != '<class \'geopandas.geodataframe.GeoDataFrame\'>'):
+        raise TypeError('data is not a GeoDataFrame and, therefore, this index cannot be calculated.')
+        
+    if ('geometry' not in data.columns):
+        data['geometry'] = data[data._geometry_column_name]
+        data = data.drop([data._geometry_column_name], axis = 1)
+        data = data.set_geometry('geometry')
+        
+    if((type(group_pop_var) is not str) or (type(total_pop_var) is not str)):
+        raise TypeError('group_pop_var and total_pop_var must be strings')
+    
+    if ((group_pop_var not in data.columns) or (total_pop_var not in data.columns)):    
+        raise ValueError('group_pop_var and total_pop_var must be variables of data')
+        
+    if (alpha < 0):
+        raise ValueError('alpha must be greater than zero.')
+    
+    if (beta < 0):
+        raise ValueError('beta must be greater than zero.')
+    
+    data = data.rename(columns={group_pop_var: 'group_pop_var', 
+                                total_pop_var: 'total_pop_var'})
+    
+    if any(data.total_pop_var < data.group_pop_var):    
+        raise ValueError('Group of interest population must equal or lower than the total population of the units.')
+    
+    data = data.assign(xi = data.group_pop_var,
+                       yi = data.total_pop_var - data.group_pop_var,
+                       c_lons = data.centroid.map(lambda p: p.x),
+                       c_lats = data.centroid.map(lambda p: p.y))
+    
+    X = data.xi.sum()
+    
+    x = np.array(data.xi)
+    t = np.array(data.total_pop_var)
+    n = len(data)
+    
+    dist = euclidean_distances(data[['c_lons','c_lats']])
+    np.fill_diagonal(dist, val = (alpha * data.area) ** (beta))
+    c = np.exp(-dist)
+    
+    ACL = ((((x/X) * (c * x).sum(axis = 1)).sum()) - ((X / n**2) * c.sum())) / \
+          ((((x/X) * (c * t).sum(axis = 1)).sum()) - ((X / n**2) * c.sum()))
+    
+    core_data = data[['group_pop_var', 'total_pop_var', 'geometry']]
+    
+    return ACL, core_data
+
+
+class Absolute_Clustering:
+    """
+    Calculation of Absolute Clustering index
+    
+    Parameters
+    ----------
+    data          : a geopandas DataFrame with a geometry column.
+    
+    group_pop_var : string
+                    The name of variable in data that contains the population size of the group of interest
+                    
+    total_pop_var : string
+                    The name of variable in data that contains the total population of the unit
+                    
+    alpha         : float
+                    A parameter that estimates the extent of the proximity within the same unit. Default value is 0.6
+    
+    beta          : float
+                    A parameter that estimates the extent of the proximity within the same unit. Default value is 0.5
+                    
+    Attributes
+    ----------
+    statistic : float
+                Absolute Clustering Index
+                
+    core_data : a geopandas DataFrame
+                A geopandas DataFrame that contains the columns used to perform the estimate.
+        
+    Examples
+    --------
+    In this example, we will calculate the absolute clustering measure (ACL) for the Riverside County using the census tract data of 2010.
+    The group of interest is non-hispanic black people which is the variable nhblk10 in the dataset.
+    
+    Firstly, we need to read the data:
+    
+    >>> # This example uses all census data that the user must provide your own copy of the external database.
+    >>> # A step-by-step procedure for downloading the data can be found here: https://github.com/spatialucr/geosnap/tree/master/geosnap/data.
+    >>> # After the user download the LTDB_Std_All_fullcount.zip and extract the files, the filepath might be something like presented below.
+    >>> filepath = '~/data/std_2010_fullcount.csv'
+    >>> census_2010 = pd.read_csv(filepath, encoding = "ISO-8859-1", sep = ",")
+    
+    Then, we filter only for the desired county (in this case, Riverside County):
+    
+    >>> df = census_2010.loc[census_2010.county == "Riverside County"][['trtid10', 'pop10','nhblk10']]
+    
+    Then, we read the Riverside map data using geopandas (the county id is 06065):
+    
+    >>> map_url = 'https://raw.githubusercontent.com/renanxcortes/inequality-segregation-supplementary-files/master/Tracts_grouped_by_County/06065.json'
+    >>> map_gpd = gpd.read_file(map_url)
+    
+    It is necessary to harmonize the data type of the dataset and the geopandas in order to work the merging procedure.
+    Later, we extract only the columns that will be used.
+    
+    >>> map_gpd['INTGEOID10'] = pd.to_numeric(map_gpd["GEOID10"])
+    >>> gdf_pre = map_gpd.merge(df, left_on = 'INTGEOID10', right_on = 'trtid10')
+    >>> gdf = gdf_pre[['geometry', 'pop10', 'nhblk10']]
+    
+    The value is estimated below.
+    
+    >>> absolute_clust_index = Absolute_Clustering(gdf, 'nhblk10', 'pop10')
+    >>> absolute_clust_index.statistic
+    0.20979814508119624
+            
+    Notes
+    -----
+    Based on Massey, Douglas S., and Nancy A. Denton. "The dimensions of residential segregation." Social forces 67.2 (1988): 281-315.
+    
+    The pairwise distance between unit i and itself is (alpha * area_of_unit_i) ^ beta.
+    
+    """
+
+    def __init__(self, data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0.5):
+        
+        aux = _absolute_clustering(data, group_pop_var, total_pop_var, alpha, beta)
+
+        self.statistic = aux[0]
+        self.core_data = aux[1]
+        self._function = _absolute_clustering
+
+
         
         
 def _relative_clustering(data, group_pop_var, total_pop_var, alpha = 0.6, beta = 0.5):

--- a/segregation/tests/test_absolute_clustering.py
+++ b/segregation/tests/test_absolute_clustering.py
@@ -1,0 +1,17 @@
+import unittest
+import libpysal
+import geopandas as gpd
+import numpy as np
+from segregation.spatial_indexes import Absolute_Clustering
+
+
+class Absolute_Clustering_Tester(unittest.TestCase):
+
+    def test_Absolute_Clustering(self):
+        s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
+        df = s_map[['geometry', 'HISP_', 'TOT_POP']]
+        index = Absolute_Clustering(df, 'HISP_', 'TOT_POP')
+        np.testing.assert_almost_equal(index.statistic, 0.005189287311955573)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the Absolute Clustering segregation measure (originally, only the Relative Clustering was present)

This adds/updates:
- function itself
- test
- notebook
- readme

It uses the exponential decay distance and also matches the values of OasisR using `spatmat = "d"` in the `ACL` function.