### PR TITLE
(bug) dual testing aganist pypi and github versions of libpysal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,15 @@ before_install:
 install:
   - conda install --yes pip nose
   - conda install --yes -c conda-forge geopandas #comment this line if geopandas is not a dependency for the package
+  - conda install --yes --file requirements.txt;
   - which pip
   - if "$PYSAL_PYPI"; then
-        echo 'testing pypi libpysal' && pip install libpysal;
-        else echo 'testing git libpysal'; git clone https://github.com/pysal/libpysal.git; cd libpysal; pip install .; cd ../;
+      echo 'testing pypi libpysal';
+    else
+      echo 'testing git libpysal';
+      pip install https://github.com/pysal/libpysal/archive/master.zip;
     fi;
-  - conda install --yes --file requirements.txt;
+
 
 script:
   - pwd


### PR DESCRIPTION
The current configuration of dual travis testing is not right. By putting [conda install --yes --file requirements.txt;](https://github.com/pysal/segregation/blob/master/.travis.yml#L42) after the pypi/github installation of `libpysal`, all travis tests actually install conda-forge release of `libpysal` although we want to test against the github version.

This PR tries to resolve the issue.