### PR TITLE
adds Multigroup Divergence Index of Roberto (2018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Currently, theses indexes are summarized in the table below:
 | Multigroup Diversity                              | Multi\_Diversity                          |      No      |     normalized      |
 | Simpson's Concentration                           | Simpsons\_Concentration                   |      No      |         \-          |
 | Simpson's Interaction                             | Simpsons\_Interaction                     |      No      |         \-          |
+| Multigroup Divergence                             | Multi\_Divergence                         |      No      |         \-          |
 
 
 

--- a/notebooks/multigroup_aspatial_examples.ipynb
+++ b/notebooks/multigroup_aspatial_examples.ipynb
@@ -348,9 +348,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:343: RuntimeWarning: divide by zero encountered in log\n",
+      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:378: RuntimeWarning: divide by zero encountered in log\n",
       "  MIT = np.nansum(ti[:,None] * pik * np.log(pik / Pk)) / (T*E)\n",
-      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:343: RuntimeWarning: invalid value encountered in multiply\n",
+      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:378: RuntimeWarning: invalid value encountered in multiply\n",
       "  MIT = np.nansum(ti[:,None] * pik * np.log(pik / Pk)) / (T*E)\n"
      ]
     },
@@ -694,6 +694,74 @@
       ]
      },
      "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index.statistic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multigroup Divergence Index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "from segregation.aspatial import Multi_Divergence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:1024: RuntimeWarning: divide by zero encountered in log\n",
+      "  Di = np.nansum(pik * np.log(pik / Pk), axis = 1)\n",
+      "c:\\users\\renan\\desktop\\segregation\\segregation\\aspatial\\multigroup_aspatial_indexes.py:1024: RuntimeWarning: invalid value encountered in multiply\n",
+      "  Di = np.nansum(pik * np.log(pik / Pk), axis = 1)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "segregation.aspatial.multigroup_aspatial_indexes.Multi_Divergence"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "index = Multi_Divergence(input_df, groups_list)\n",
+    "type(index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.16645182134289443"
+      ]
+     },
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/segregation/aspatial/multigroup_aspatial_indexes.py
+++ b/segregation/aspatial/multigroup_aspatial_indexes.py
@@ -18,7 +18,8 @@ __all__ = ['Multi_Dissim',
            'Multi_Squared_Coefficient_of_Variation',
            'Multi_Diversity',
            'Simpsons_Concentration',
-           'Simpsons_Interaction']
+           'Simpsons_Interaction',
+           'Multi_Divergence']
 
 def _multi_dissim(data, groups):
     """
@@ -980,3 +981,105 @@ class Simpsons_Interaction:
         self.statistic = aux[0]
         self.core_data = aux[1]
         self._function = _simpsons_interaction
+        
+        
+        
+def _multi_divergence(data, groups):
+    """
+    Calculation of Multigroup Divergence index
+
+    Parameters
+    ----------
+
+    data   : a pandas DataFrame
+    
+    groups : list of strings.
+             The variables names in data of the groups of interest of the analysis.
+
+    Returns
+    -------
+
+    statistic : float
+                Multigroup Divergence Index
+                
+    core_data : a pandas DataFrame
+                A pandas DataFrame that contains the columns used to perform the estimate.
+
+    Notes
+    -----
+    Based on Roberto, Elizabeth. "The Divergence Index: A Decomposable Measure of Segregation and Inequality." arXiv preprint arXiv:1508.01167 (2015).
+
+    """
+    
+    core_data = data[groups]
+    
+    df = np.array(core_data)
+    
+    T = df.sum()
+    
+    ti = df.sum(axis = 1)
+    pik = df/ti[:,None]
+    Pk = df.sum(axis = 0) / df.sum()
+    
+    Di = np.nansum(pik * np.log(pik / Pk), axis = 1)
+
+    Divergence_Index = ((ti / T) * Di).sum()
+    
+    return Divergence_Index, core_data
+
+
+class Multi_Divergence:
+    """
+    Calculation of Multigroup Divergence index
+
+    Parameters
+    ----------
+
+    data   : a pandas DataFrame
+    
+    groups : list of strings.
+             The variables names in data of the groups of interest of the analysis.
+
+    Attributes
+    ----------
+
+    statistic : float
+                Multigroup Divergence Index
+                
+    core_data : a pandas DataFrame
+                A pandas DataFrame that contains the columns used to perform the estimate.
+
+    Examples
+    --------
+    In this example, we are going to use 2000 Census Tract Data for Sacramento MSA, CA. The groups of interest are White, Black, Asian and Hispanic population.
+    
+    Firstly, we need to perform some import the modules and the respective function.
+    
+    >>> import libpysal
+    >>> import geopandas as gpd
+    >>> from segregation.multigroup_aspatial import Multi_Divergence
+    
+    Then, we read the data and create an auxiliary list with only the necessary columns for fitting the index.
+    
+    >>> input_df = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
+    >>> groups_list = ['WHITE_', 'BLACK_', 'ASIAN_','HISP_']
+    
+    The value is estimated below.
+    
+    >>> index = Multi_Divergence(input_df, groups_list)
+    >>> index.statistic
+    0.16645182134289443
+
+    Notes
+    -----
+    Based on Roberto, Elizabeth. "The Divergence Index: A Decomposable Measure of Segregation and Inequality." arXiv preprint arXiv:1508.01167 (2015).
+
+    """
+    
+    def __init__(self, data, groups):
+        
+        aux = _multi_divergence(data, groups)
+
+        self.statistic = aux[0]
+        self.core_data = aux[1]
+        self._function = _multi_divergence

--- a/segregation/tests/test_multi_divergence.py
+++ b/segregation/tests/test_multi_divergence.py
@@ -1,0 +1,18 @@
+import unittest
+import libpysal
+import geopandas as gpd
+import numpy as np
+from segregation.aspatial import Multi_Divergence
+
+
+class Multi_Divergence_Tester(unittest.TestCase):
+    def test_Multi_Divergence(self):
+        s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
+        groups_list = ['WHITE_', 'BLACK_', 'ASIAN_','HISP_']
+        df = s_map[groups_list]
+        index = Multi_Divergence(df, groups_list)
+        np.testing.assert_almost_equal(index.statistic, 0.16645182134289443)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This implements the index presented in Roberto, Elizabeth. "The Divergence Index: A Decomposable Measure of Segregation and Inequality." arXiv preprint arXiv:1508.01167 (2015). The results are similar to the Multigroup Information Theory index.

This is the index used in Roberto, Elizabeth. "The Spatial Proximity and Connectivity Method for Measuring and Analyzing Residential Segregation." Sociological Methodology 48.1 (2018): 182-224.

ps.: the spatial version of it is accomplished by replacing the p_i by "tilde p_i"  just as in the network use case.

The formula of the index add in this PR follows:

![image](https://user-images.githubusercontent.com/22593188/59475541-ef73d200-8e00-11e9-9bec-c95d008994e9.png)
