### PR TITLE
enh: add plotting tests in the decomposition framework

### DIFF
--- a/segregation/tests/test_decomposition.py
+++ b/segregation/tests/test_decomposition.py
@@ -14,15 +14,20 @@ class Decomposition_Tester(unittest.TestCase):
         res = DecomposeSegregation(index1, index2, counterfactual_approach = "composition")
         np.testing.assert_almost_equal(res.c_a, -0.16138819842911295)
         np.testing.assert_almost_equal(res.c_s, -0.005104643275796905)
+        res.plot(plot_type = 'cdfs')
+        res.plot(plot_type = 'maps')
         
         res = DecomposeSegregation(index1, index2, counterfactual_approach = "share")
         np.testing.assert_almost_equal(res.c_a, -0.1543828579279878)
         np.testing.assert_almost_equal(res.c_s, -0.012109983776922045)
+        res.plot(plot_type = 'cdfs')
+        res.plot(plot_type = 'maps')
         
         res = DecomposeSegregation(index1, index2, counterfactual_approach = "dual_composition")
         np.testing.assert_almost_equal(res.c_a, -0.16159526946235048)
         np.testing.assert_almost_equal(res.c_s, -0.004897572242559378)
-
+        res.plot(plot_type = 'cdfs')
+        res.plot(plot_type = 'maps')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds the plotting methods of the decomposition for the tests.
This will considerably increase the coverage %.

I tested locally, and this works just fine.