### PR TITLE
bug: add descartes in requirements_tests for plotting tests

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -8,3 +8,4 @@ pandas
 ipywidgets
 pandana
 urbanaccess
+descartes


### PR DESCRIPTION
Travis Build was breaking. I think this will solve the issue since all the tests are pointing to this .txt.