### PR TITLE
[WIP] add libcfitsio-dev in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 addons:
   apt:
     packages:
-    - libcfitsio
+    - libcfitsio-dev
 
 script:
   - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ install:
       pip install https://github.com/pysal/libpysal/archive/master.zip;
     fi;
 
+addons:
+  apt:
+    packages:
+    - libcfitsio.so.5
 
 script:
   - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 addons:
   apt:
     packages:
-    - libcfitsio.so.5
+    - libcfitsio
 
 script:
   - pwd


### PR DESCRIPTION
Just wanted to open this PR see the TravisCI log on PySAL's side (we do not need to merge this). I think that even managing to install `libcfitsio-dev`, the error below persists:

```
======================================================================
ERROR: Failure: ImportError (libcfitsio.so.5: cannot open shared object file: No
```