### PR TITLE
Adds inference wrappers for multigroup indexes (Single and Two)

### DIFF
--- a/segregation/aspatial/multigroup_aspatial_indexes.py
+++ b/segregation/aspatial/multigroup_aspatial_indexes.py
@@ -98,7 +98,7 @@ def _multi_dissim(data, groups):
         abs(pik - Pk),
         np.repeat(ti, K, axis=0).reshape(n, K)).sum()
 
-    return multi_D, core_data
+    return multi_D, core_data, groups
 
 
 class MultiDissim:
@@ -157,6 +157,7 @@ class MultiDissim:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_dissim
 
 
@@ -210,7 +211,7 @@ def _multi_gini_seg(data, groups):
 
     multi_Gini_Seg = elements_sum.sum() / (2 * (T**2) * Is)
 
-    return multi_Gini_Seg, core_data
+    return multi_Gini_Seg, core_data, groups
 
 
 class MultiGiniSeg:
@@ -269,6 +270,7 @@ class MultiGiniSeg:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_gini_seg
 
 
@@ -313,7 +315,7 @@ def _multi_normalized_exposure(data, groups):
 
     MNE = ((ti[:, None] * (pik - Pk)**2) / (1 - Pk)).sum() / T
 
-    return MNE, core_data
+    return MNE, core_data, groups
 
 
 class MultiNormalizedExposure:
@@ -372,6 +374,7 @@ class MultiNormalizedExposure:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_normalized_exposure
 
 
@@ -420,7 +423,7 @@ def _multi_information_theory(data, groups):
 
     MIT = np.nansum(ti[:, None] * pik * np.log(pik / Pk)) / (T * E)
 
-    return MIT, core_data
+    return MIT, core_data, groups
 
 
 class MultiInformationTheory:
@@ -479,6 +482,7 @@ class MultiInformationTheory:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_information_theory
 
 
@@ -526,7 +530,7 @@ def _multi_relative_diversity(data, groups):
 
     MRD = (ti[:, None] * (pik - Pk)**2).sum() / (T * Is)
 
-    return MRD, core_data
+    return MRD, core_data, groups
 
 
 class MultiRelativeDiversity:
@@ -587,6 +591,7 @@ class MultiRelativeDiversity:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_relative_diversity
 
 
@@ -633,7 +638,7 @@ def _multi_squared_coefficient_of_variation(data, groups):
 
     C = ((ti[:, None] * (pik - Pk)**2) / (T * (K - 1) * Pk)).sum()
 
-    return C, core_data
+    return C, core_data, groups
 
 
 class MultiSquaredCoefficientVariation:
@@ -692,6 +697,7 @@ class MultiSquaredCoefficientVariation:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_squared_coefficient_of_variation
 
 
@@ -743,7 +749,7 @@ def _multi_diversity(data, groups, normalized=False):
         K = df.shape[1]
         E = E / np.log(K)
 
-    return E, core_data
+    return E, core_data, groups
 
 
 class MultiDiversity:
@@ -812,6 +818,7 @@ class MultiDiversity:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_diversity
 
 
@@ -858,7 +865,7 @@ def _simpsons_concentration(data, groups):
 
     Lambda = (Pk * Pk).sum()
 
-    return Lambda, core_data
+    return Lambda, core_data, groups
 
 
 class SimpsonsConcentration:
@@ -923,6 +930,7 @@ class SimpsonsConcentration:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _simpsons_concentration
 
 
@@ -969,7 +977,7 @@ def _simpsons_interaction(data, groups):
 
     I = (Pk * (1 - Pk)).sum()
 
-    return I, core_data
+    return I, core_data, groups
 
 
 class SimpsonsInteraction:
@@ -1034,6 +1042,7 @@ class SimpsonsInteraction:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _simpsons_interaction
 
 
@@ -1080,7 +1089,7 @@ def _multi_divergence(data, groups):
 
     Divergence_Index = ((ti / T) * Di).sum()
 
-    return Divergence_Index, core_data
+    return Divergence_Index, core_data, groups
 
 
 class MultiDivergence:
@@ -1139,6 +1148,7 @@ class MultiDivergence:
 
         self.statistic = aux[0]
         self.core_data = aux[1]
+        self._groups   = aux[2]
         self._function = _multi_divergence
 
 

--- a/segregation/inference/inference_wrappers.py
+++ b/segregation/inference/inference_wrappers.py
@@ -187,12 +187,13 @@ def _infer_segregation(seg_class,
                     
         if ('multigroup' in str(type(seg_class))):
             
+            df = np.array(seg_class.core_data)
+            global_prob_vector = df.sum(axis = 0) / df.sum()
+            t = df.sum(axis = 1)
+            
             with tqdm(total=iterations_under_null) as pbar:
                 for i in np.array(range(iterations_under_null)):
             
-                    df = np.array(seg_class.core_data)
-                    global_prob_vector = df.sum(axis = 0) / df.sum()
-                    t = df.sum(axis = 1)
                     simul = map(lambda i: list(np.random.multinomial(i, global_prob_vector)), t)
                     df_simul = pd.DataFrame(list(simul), columns = seg_class._groups)
                     

--- a/segregation/tests/test_inference.py
+++ b/segregation/tests/test_inference.py
@@ -2,7 +2,7 @@ import unittest
 import libpysal
 import geopandas as gpd
 import numpy as np
-from segregation.aspatial import Dissim
+from segregation.aspatial import Dissim, MultiDissim
 from segregation.inference import SingleValueTest, TwoValueTest
 
 
@@ -11,6 +11,9 @@ class Inference_Tester(unittest.TestCase):
         s_map = gpd.read_file(libpysal.examples.get_path("sacramentot2.shp"))
         index1 = Dissim(s_map, 'HISP_', 'TOT_POP')
         index2 = Dissim(s_map, 'BLACK_', 'TOT_POP')
+        
+        groups_list = ['WHITE_', 'BLACK_', 'ASIAN_','HISP_']
+        m_index = MultiDissim(s_map, groups_list)
         
         # Single Value Tests #
         np.random.seed(123)
@@ -36,6 +39,14 @@ class Inference_Tester(unittest.TestCase):
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "even_permutation", iterations_under_null = 50)
         np.testing.assert_almost_equal(res.est_sim.mean(), 0.01619436868061094)
+        
+        np.random.seed(123)
+        res = SingleValueTest(m_index, null_approach = "bootstrap", iterations_under_null = 50)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.4143544081847027)
+        
+        np.random.seed(123)
+        res = SingleValueTest(m_index, null_approach = "evenness", iterations_under_null = 50)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01633979237418177)
 
         # Two Value Tests #
         np.random.seed(123)

--- a/segregation/tests/test_inference.py
+++ b/segregation/tests/test_inference.py
@@ -14,6 +14,9 @@ class Inference_Tester(unittest.TestCase):
         
         groups_list = ['WHITE_', 'BLACK_', 'ASIAN_','HISP_']
         m_index = MultiDissim(s_map, groups_list)
+		
+        m_index_1 = MultiDissim(s_map[0:200], groups_list)
+        m_index_2 = MultiDissim(s_map[200:] , groups_list)
         
         # Single Value Tests #
         np.random.seed(123)
@@ -51,7 +54,7 @@ class Inference_Tester(unittest.TestCase):
         # Two Value Tests #
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "random_label", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), -0.0013532591859387643)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.0031386146371949076)
         
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "counterfactual_composition", iterations_under_null = 50)
@@ -64,6 +67,10 @@ class Inference_Tester(unittest.TestCase):
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "counterfactual_dual_composition", iterations_under_null = 50)
         np.testing.assert_almost_equal(res.est_sim.mean(), -0.004771386292706747)
+		
+        np.random.seed(123)
+        res = TwoValueTest(m_index_1, m_index_2, null_approach = "random_label", iterations_under_null = 50)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.0024327144012562685)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds the "evenness" and "bootstrap" approach for MultiGroup indexes as raised in https://github.com/pysal/segregation/issues/86. Some of the formattings were changed as I thought It was easier to spot which lines to change in the code and how to properly construct the null hypothesis.

I assumed that the evenness approach is simply the generalization of the single group approach, as every unit had a fixed vector of probability of allocating for each subgroup. However, the difference is that now the simulation is a multinomial distribution in the tract level. So, we need to simulate many multinomial distributions and I achieved that using a `map` function.

This is still a WIP since I'd like to add the `random_label` approach for comparing two Multigroup Measures.

Edit: I added the MultiGroup case for two indexes, so removed the WIP of the name of this PR.