### PR TITLE
Increase the precision of simulated-based tests.

### DIFF
--- a/segregation/tests/test_bias_corrected_dissimilarity.py
+++ b/segregation/tests/test_bias_corrected_dissimilarity.py
@@ -11,7 +11,7 @@ class Bias_Corrected_Dissim_Tester(unittest.TestCase):
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         np.random.seed(1234)
         index = BiasCorrectedDissim(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.32136474449360836)
+        np.testing.assert_almost_equal(index.statistic, 0.32136474449360836, decimal = 3)
 
 
 if __name__ == '__main__':

--- a/segregation/tests/test_compute_all.py
+++ b/segregation/tests/test_compute_all.py
@@ -13,13 +13,13 @@ class ComputeAll_Tester(unittest.TestCase):
         res = ComputeAllAspatialSegregation(s_map, 'HISP_', 'TOT_POP')
         np.testing.assert_almost_equal(np.array(res.computed['Value']), np.array([0.32184656, 0.43506511, 0.09459761, 0.15079259, 0.76803845,
         0.23196155, 0.13768748, 0.32141961, 0.29520516, 0.09164042,
-        0.31074587, 0.42179274]))
+        0.31074587, 0.42179274]), decimal = 3)
     
         np.random.seed(123)
         res = ComputeAllSpatialSegregation(s_map, 'HISP_', 'TOT_POP')
         np.testing.assert_almost_equal(np.array(res.computed['Value']), np.array([ 0.26119743,  0.68914224,  0.00518929,  0.85128245,  0.80449692,
        -0.11194178,  0.00909563,  0.12733821,  0.83965834,  0.15621625,
-        0.22847334,  1.00266235,  0.26676264,  0.31117181]))
+        0.22847334,  1.00266235,  0.26676264,  0.31117181]), decimal = 3)
     
         np.random.seed(123)
         res = ComputeAllSegregation(s_map, 'HISP_', 'TOT_POP')
@@ -28,7 +28,7 @@ class ComputeAll_Tester(unittest.TestCase):
         0.31074587,  0.42179274,  0.26119743,  0.68914224,  0.00518929,
         0.85128245,  0.80449692, -0.11194178,  0.00909563,  0.12733821,
         0.83965834,  0.15621625,  0.22847334,  1.00266235,  0.26676264,
-        0.31117181]))
+        0.31117181]), decimal = 3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/segregation/tests/test_inference.py
+++ b/segregation/tests/test_inference.py
@@ -15,44 +15,44 @@ class Inference_Tester(unittest.TestCase):
         # Single Value Tests #
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "systematic", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01603886544282861)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01603886544282861, decimal = 3)
         
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "bootstrap", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.31992467511262773)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.31992467511262773, decimal = 3)
         
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "evenness", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01596295861644252)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01596295861644252, decimal = 3)
         
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "permutation", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.32184656076566864)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.32184656076566864, decimal = 3)
         
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "systematic_permutation", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01603886544282861)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01603886544282861, decimal = 3)
         
         np.random.seed(123)
         res = SingleValueTest(index1, null_approach = "even_permutation", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01619436868061094)
+        np.testing.assert_almost_equal(res.est_sim.mean(), 0.01619436868061094, decimal = 3)
 
         # Two Value Tests #
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "random_label", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), -0.0013532591859387643)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.0013532591859387643, decimal = 3)
         
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "counterfactual_composition", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), -0.005032145622504718)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.005032145622504718, decimal = 3)
         
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "counterfactual_share", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), -0.034350440515125)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.034350440515125, decimal = 3)
         
         np.random.seed(123)
         res = TwoValueTest(index1, index2, null_approach = "counterfactual_dual_composition", iterations_under_null = 50)
-        np.testing.assert_almost_equal(res.est_sim.mean(), -0.004771386292706747)
+        np.testing.assert_almost_equal(res.est_sim.mean(), -0.004771386292706747, decimal = 3)
 
 
 if __name__ == '__main__':

--- a/segregation/tests/test_modified_dissimilarity.py
+++ b/segregation/tests/test_modified_dissimilarity.py
@@ -11,7 +11,7 @@ class Modified_Dissim_Tester(unittest.TestCase):
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         np.random.seed(1234)
         index = ModifiedDissim(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.31075891224250635)
+        np.testing.assert_almost_equal(index.statistic, 0.31075891224250635, decimal = 3)
 
 
 if __name__ == '__main__':

--- a/segregation/tests/test_modified_gini.py
+++ b/segregation/tests/test_modified_gini.py
@@ -12,7 +12,7 @@ class Modified_Gini_Seg_Tester(unittest.TestCase):
         df = s_map[['geometry', 'HISP_', 'TOT_POP']]
         np.random.seed(1234)
         index = ModifiedGiniSeg(df, 'HISP_', 'TOT_POP')
-        np.testing.assert_almost_equal(index.statistic, 0.4217844443896344)
+        np.testing.assert_almost_equal(index.statistic, 0.4217844443896344, decimal = 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It addresses https://github.com/pysal/segregation/issues/123.

It covers inference, some segregation indexes and inference wrappers.