### PR TITLE
remove mamba reference

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -34,7 +34,6 @@
        - uses: conda-incubator/setup-miniconda@v2
          with:
             miniconda-version: 'latest'
-            mamba-version: '*'
             channels: conda-forge
             channel-priority: true
             auto-update-conda: false

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -35,7 +35,7 @@
          with:
             miniconda-version: 'latest'
             channels: conda-forge
-            channel-priority: true
+            channel-priority: strict
             auto-update-conda: false
             auto-activate-base: false
             environment-file: ${{ matrix.environment-file }}


### PR DESCRIPTION
This PR removes the `mamba` reference in [`unittests.yml`](https://github.com/pysal/segregation/blob/2fbc4393cd8f6b09c4b8e2a5f26ca1b88125cb88/.github/workflows/unittests.yml#L37), which appears to be screwing up the channel priority settings resulting in a bad `rtree` install on Windows.

See pysal/spaghetti#610 and conda-forge/rtree-feedstock#31