### PR TITLE
fix warning in length-weighted W matrix

### DIFF
--- a/segregation/_base.py
+++ b/segregation/_base.py
@@ -38,7 +38,7 @@ def _return_length_weighted_w(data):
     if len(w.islands) == 0:
         w = w
     else:
-        warnings("There are some islands in the GeoDataFrame.")
+        warnings.warn("There are some islands in the GeoDataFrame.")
         w_aux = libpysal.weights.KNN.from_dataframe(
             data, ids=data.index.tolist(), geom_col=data._geometry_column_name, k=1
         )

--- a/segregation/decomposition/decompose_segregation.py
+++ b/segregation/decomposition/decompose_segregation.py
@@ -212,7 +212,7 @@ class DecomposeSegregation:
             temp_a["Location"] = city_a
             temp_b = self._counterfac_df2.copy()
             temp_b["Location"] = city_b
-            df = pd.concat([temp_a, temp_b])
+            df = pd.concat([temp_a, temp_b]).reset_index()
 
             if self._counterfactual_approach == "composition":
                 sns.ecdfplot(data=df, x="group_composition", hue="Location", ax=ax)

--- a/segregation/multigroup/multi_dissim.py
+++ b/segregation/multigroup/multi_dissim.py
@@ -96,7 +96,8 @@ class MultiDissim(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
 

--- a/segregation/multigroup/multi_divergence.py
+++ b/segregation/multigroup/multi_divergence.py
@@ -94,7 +94,8 @@ class MultiDivergence(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
 

--- a/segregation/multigroup/multi_diversity.py
+++ b/segregation/multigroup/multi_diversity.py
@@ -106,7 +106,8 @@ class MultiDiversity(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/multi_gini.py
+++ b/segregation/multigroup/multi_gini.py
@@ -99,6 +99,7 @@ class MultiGini(MultiGroupIndex, SpatialImplicitIndex):
         decay='linear',
         function='triangular',
         precompute=False,
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/multi_info_theory.py
+++ b/segregation/multigroup/multi_info_theory.py
@@ -101,6 +101,7 @@ class MultiInfoTheory(MultiGroupIndex, SpatialImplicitIndex):
         decay='linear',
         function='triangular',
         precompute=False,
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/multi_norm_exposure.py
+++ b/segregation/multigroup/multi_norm_exposure.py
@@ -98,7 +98,8 @@ class MultiNormExposure(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/multi_relative_diversity.py
+++ b/segregation/multigroup/multi_relative_diversity.py
@@ -101,7 +101,8 @@ class MultiRelativeDiversity(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/multi_squared_coef_var.py
+++ b/segregation/multigroup/multi_squared_coef_var.py
@@ -100,7 +100,8 @@ class MultiSquaredCoefVar(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/simpsons_concentration.py
+++ b/segregation/multigroup/simpsons_concentration.py
@@ -99,7 +99,8 @@ class SimpsonsConcentration(MultiGroupIndex, SpatialImplicitIndex):
         distance=None,
         decay=None,
         precompute=None,
-        function='triangular'
+        function='triangular',
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/multigroup/simpsons_interaction.py
+++ b/segregation/multigroup/simpsons_interaction.py
@@ -105,6 +105,7 @@ class SimpsonsInteraction(MultiGroupIndex, SpatialImplicitIndex):
         decay=None,
         precompute=None,
         function="triangular",
+        **kwargs
     ):
         """Init."""
         MultiGroupIndex.__init__(self, data, groups)

--- a/segregation/singlegroup/boundary_spatial_dissim.py
+++ b/segregation/singlegroup/boundary_spatial_dissim.py
@@ -54,9 +54,9 @@ def _boundary_spatial_dissim(data, group_pop_var, total_pop_var, standardize=Fal
     )
 
     if not standardize:
-        cij = _return_length_weighted_w(data).full()[0]
+        cij = _return_length_weighted_w(data).sparse.todense()
     else:
-        cij = _return_length_weighted_w(data).full()[0]
+        cij = _return_length_weighted_w(data).sparse.todense()
         cij = cij / cij.sum(axis=1).reshape((cij.shape[0], 1))
 
     # manhattan_distances used to compute absolute distances

--- a/segregation/singlegroup/par_dissim.py
+++ b/segregation/singlegroup/par_dissim.py
@@ -56,9 +56,9 @@ def _perimeter_area_ratio_spatial_dissim(
     )
 
     if not standardize:
-        cij = _return_length_weighted_w(data).full()[0]
+        cij = _return_length_weighted_w(data).sparse.toarray()
     else:
-        cij = _return_length_weighted_w(data).full()[0]
+        cij = _return_length_weighted_w(data).sparse.toarray()
         cij = cij / cij.sum()
 
     peri = data.length


### PR DESCRIPTION
- fix warning for islands (currently it will raise an error if triggered, we're calling `warnings` instead of `warnings.warn`)
- allow extra kwargs in multigroup indices
- faster densifying W in pardissim and bsd
