### PR TITLE
Add Python 3.14 to CI test matrix (#1382)

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,6 +28,7 @@
             ci/311.yml,
             ci/312.yml,
             ci/313.yml,
+            ci/314.yml,
          ]
          include:
            - environment-file: ci/312.yml

--- a/ci/314.yml
+++ b/ci/314.yml
@@ -1,0 +1,31 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.14
+  - deprecation
+  - geopandas>=0.9
+  - joblib
+  - libpysal
+  - mapclassify
+  - matplotlib
+  - numpy
+  - pandana
+  - pandas
+  - pip
+  - quilt3
+  - scikit-learn
+  - scipy
+  - seaborn
+  - tqdm
+  - urbanaccess
+  - numba
+  - pyproj >=3
+
+  # testing, etc
+  - codecov
+  - pytest
+  - pytest-mpl
+  - pytest-cov
+  - pytest-xdist
+  - twine


### PR DESCRIPTION
- Created ci/314.yml environment file for Python 3.14

- Added ci/314.yml to test matrix

- Addresses pysal/pysal#1382