### PR TITLE
Add the CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Segregation Analysis, Inference, and Decomposition with PySAL
 
+[![Continuous Integration](https://github.com/pysal/segregation/actions/workflows/unittests.yml/badge.svg?branch=main)](https://github.com/pysal/segregation/actions/workflows/unittests.yml)
 [![codecov](https://codecov.io/gh/pysal/segregation/branch/main/graph/badge.svg?token=1ujvZCI9Ce)](https://codecov.io/gh/pysal/segregation)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/segregation)
 ![PyPI](https://img.shields.io/pypi/v/segregation)


### PR DESCRIPTION
The README has badges for coverage, PyPI, conda, commits-since, DOI and docs, but nothing for the test suite, so build status is not visible without opening the Actions tab.

Added one for `unittests.yml`, placed above the codecov badge.

I checked each workflow badge first and used only this one. `build_docs.yml` currently reports failing and `upload_package.yml` reports no status on `main`, so neither is included.